### PR TITLE
PuchaseHistoriesの合計値計算時に合計値を0に初期化する処理を追加。

### DIFF
--- a/src/hooks/usePurchaseHistoryHooks.ts
+++ b/src/hooks/usePurchaseHistoryHooks.ts
@@ -22,6 +22,7 @@ export const usePurchaseHistoryHooks = ():PurchaseHistoryHooks =>{
     const [sumPurchaseHistoriesAmount, setSumPurchaseHistoriesAmount] = useState<number>(0);
 
     const calcPurchaseHistoriesAmount = () => {
+        setSumPurchaseHistoriesAmount(0)
         purchaseHistories.map((history:PurchaseHistory) =>{
             const {pay_total_amount, total_target_flag} = history
             if(total_target_flag){


### PR DESCRIPTION
# PuchaseHistory 合計値計算　バグ修正
PuchaseHistoryの合計値を計算する処理を起動した際に、合計値が積み上がっていってしまうバグが発生。
合計値の計算を行う際に0で初期化する処理を追加しバグを修正した。